### PR TITLE
Add View as Markdown support from Issue #1

### DIFF
--- a/apps/chrome-extension/_locales/en/messages.json
+++ b/apps/chrome-extension/_locales/en/messages.json
@@ -5,6 +5,9 @@
   "copy_docx_as_markdown": {
     "message": "Copy as Markdown"
   },
+  "view_docx_as_markdown": {
+    "message": "View as Markdown"
+  },
   "help_and_feedback": {
     "message": "Help and Feedback"
   }

--- a/apps/chrome-extension/_locales/zh_CN/messages.json
+++ b/apps/chrome-extension/_locales/zh_CN/messages.json
@@ -5,6 +5,9 @@
   "copy_docx_as_markdown": {
     "message": "复制为 Markdown"
   },
+  "view_docx_as_markdown": {
+    "message": "查看为 Markdown"
+  },
   "help_and_feedback": {
     "message": "帮助和反馈"
   }

--- a/apps/chrome-extension/src/background.ts
+++ b/apps/chrome-extension/src/background.ts
@@ -3,6 +3,7 @@ import { type Message } from './common/message'
 enum MenuItemId {
   DOWNLOAD_DOCX_AS_MARKDOWN = 'download_docx_as_markdown',
   COPY_DOCX_AS_MARKDOWN = 'copy_docx_as_markdown',
+  VIEW_DOCX_AS_MARKDOWN = 'view_docx_as_markdown',
 }
 
 chrome.runtime.onInstalled.addListener(() => {
@@ -31,6 +32,19 @@ chrome.runtime.onInstalled.addListener(() => {
     ],
     contexts: ['page', 'editable'],
   })
+
+  chrome.contextMenus.create({
+    id: MenuItemId.VIEW_DOCX_AS_MARKDOWN,
+    title: chrome.i18n.getMessage('view_docx_as_markdown'),
+    documentUrlPatterns: [
+      'https://*.feishu.cn/*',
+      'https://*.feishu.net/*',
+      'https://*.larksuite.com/*',
+      'https://*.feishu-pre.net/*',
+      'https://*.larkoffice.com/*',
+    ],
+    contexts: ['page', 'editable'],
+  })
 })
 
 const executeScriptByFlag = async (flag: string | number, tabId: number) => {
@@ -45,6 +59,13 @@ const executeScriptByFlag = async (flag: string | number, tabId: number) => {
     case MenuItemId.COPY_DOCX_AS_MARKDOWN:
       await chrome.scripting.executeScript({
         files: ['bundles/scripts/copy-lark-docx-as-markdown.js'],
+        target: { tabId },
+        world: 'MAIN',
+      })
+      break
+    case MenuItemId.VIEW_DOCX_AS_MARKDOWN:
+      await chrome.scripting.executeScript({
+        files: ['bundles/scripts/view-lark-docx-as-markdown.js'],
         target: { tabId },
         world: 'MAIN',
       })

--- a/apps/chrome-extension/src/common/message.ts
+++ b/apps/chrome-extension/src/common/message.ts
@@ -1,4 +1,5 @@
 export enum Flag {
+  ExecuteViewScript = 'view_docx_as_markdown',
   ExecuteCopyScript = 'copy_docx_as_markdown',
   ExecuteDownloadScript = 'download_docx_as_markdown',
 }

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -72,16 +72,23 @@ const initButtons = (): void => {
         },
       },
       {
+        type: 'view',
+        innerHtml: `
+        `,
+        action: () => {
+          chrome.runtime
+            .sendMessage({ flag: 'view_docx_as_markdown' })
+            .catch(console.error)
+        },
+      },
+      {
         type: 'download',
-        innerHtml: `<svg aria-hidden="true" focusable="false" role="img" class="octicon octicon-download" viewBox="0 0 16 16"
-        width="16" height="16" fill="currentColor">
-        <path
-          d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z">
-        </path>
-        <path
-          d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z">
-        </path>
-      </svg>`,
+        innerHtml: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" 
+        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
+        class="octicon octicon-view" fill="currentColor">
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8"/>
+          <circle cx="12" cy="12" r="3"/>
+        </svg>`,
         action: () => {
           chrome.runtime
             .sendMessage({ flag: 'download_docx_as_markdown' })

--- a/apps/chrome-extension/src/content.ts
+++ b/apps/chrome-extension/src/content.ts
@@ -73,7 +73,12 @@ const initButtons = (): void => {
       },
       {
         type: 'view',
-        innerHtml: `
+        innerHtml: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" 
+        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
+        class="octicon octicon-view" fill="currentColor">
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8"/>
+          <circle cx="12" cy="12" r="3"/>
+        </svg>
         `,
         action: () => {
           chrome.runtime
@@ -83,12 +88,15 @@ const initButtons = (): void => {
       },
       {
         type: 'download',
-        innerHtml: `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" 
-        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
-        class="octicon octicon-view" fill="currentColor">
-          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8"/>
-          <circle cx="12" cy="12" r="3"/>
-        </svg>`,
+        innerHtml: `<svg aria-hidden="true" focusable="false" role="img" class="octicon octicon-download" viewBox="0 0 16 16"
+        width="16" height="16" fill="currentColor">
+        <path
+          d="M2.75 14A1.75 1.75 0 0 1 1 12.25v-2.5a.75.75 0 0 1 1.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 0 0 .25-.25v-2.5a.75.75 0 0 1 1.5 0v2.5A1.75 1.75 0 0 1 13.25 14Z">
+        </path>
+        <path
+          d="M7.25 7.689V2a.75.75 0 0 1 1.5 0v5.689l1.97-1.969a.749.749 0 1 1 1.06 1.06l-3.25 3.25a.749.749 0 0 1-1.06 0L4.22 6.78a.749.749 0 1 1 1.06-1.06l1.97 1.969Z">
+        </path>
+      </svg>`,
         action: () => {
           chrome.runtime
             .sendMessage({ flag: 'download_docx_as_markdown' })

--- a/apps/chrome-extension/src/popup/popup.html
+++ b/apps/chrome-extension/src/popup/popup.html
@@ -3,6 +3,16 @@
 <body>
   <ul>
     <li>
+       <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" 
+        stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" 
+        class="octicon octicon-view" fill="currentColor">
+          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8"/>
+          <circle cx="12" cy="12" r="3"/>
+        </svg>
+      <button id="view_docx_as_markdown" data-locale="view_docx_as_markdown">View as
+        Markdown</button>
+    </li>
+    <li>
       <svg aria-hidden="true" focusable="false" role="img" class="octicon octicon-copy" viewBox="0 0 16 16" width="16"
         height="16" fill="currentColor">
         <path

--- a/apps/chrome-extension/src/popup/popup.ts
+++ b/apps/chrome-extension/src/popup/popup.ts
@@ -17,6 +17,21 @@ if (copyButton) {
   })
 }
 
+const viewButton: HTMLElement | null = document.getElementById(
+  'view_docx_as_markdown',
+)
+if (viewButton) {
+  const handleView = async () => {
+    await chrome.runtime.sendMessage({ flag: 'view_docx_as_markdown' })
+
+    window.close()
+  }
+
+  viewButton.addEventListener('click', () => {
+    handleView().catch(console.error)
+  })
+}
+
 const downloadButton: HTMLElement | null = document.getElementById(
   'download_docx_as_markdown',
 )

--- a/apps/chrome-extension/src/scripts/view-lark-docx-as-markdown.ts
+++ b/apps/chrome-extension/src/scripts/view-lark-docx-as-markdown.ts
@@ -1,0 +1,152 @@
+import i18next from 'i18next'
+import { Docx, docx, Toast } from '@dolphin/lark'
+import { generatePublicUrl, makePublicUrlEffective } from '@dolphin/lark/image'
+import { isDefined } from '@dolphin/common'
+import { CommonTranslationKey, en, Namespace, zh } from '../common/i18n'
+import { confirm } from '../common/notification'
+import { reportBug } from '../common/issue'
+
+const enum TranslationKey {
+  FAILED_TO_LOAD_IMAGES = 'failed_to_load_images',
+  UNKNOWN_ERROR = 'unknown_error',
+  CONTENT_LOADING = 'content_loading',
+  NOT_SUPPORT = 'not_support',
+  FAILED_TO_OPEN_WINDOW = 'failed_to_open_window',
+}
+
+i18next
+  .init({
+    lng: docx.language,
+    resources: {
+      en: {
+        translation: {
+          [TranslationKey.FAILED_TO_LOAD_IMAGES]: 'Failed to Load images',
+          [TranslationKey.UNKNOWN_ERROR]: 'Unknown error during download',
+          [TranslationKey.CONTENT_LOADING]:
+            'Part of the content is still loading and cannot be copied at the moment. Please wait for loading to complete and retry',
+          [TranslationKey.NOT_SUPPORT]:
+            'This is not a lark document page and cannot be copied as Markdown',
+          [TranslationKey.FAILED_TO_OPEN_WINDOW]:
+            'Failed to Open a new window to display markdown.',
+        },
+        ...en,
+      },
+      zh: {
+        translation: {
+          [TranslationKey.FAILED_TO_LOAD_IMAGES]: '加载图片失败',
+          [TranslationKey.UNKNOWN_ERROR]: '下载过程中出现未知错误',
+          [TranslationKey.CONTENT_LOADING]:
+            '部分内容仍在加载中，暂时无法复制。请等待加载完成后重试',
+          [TranslationKey.NOT_SUPPORT]:
+            '这不是一个飞书文档页面，无法复制为 Markdown',
+          [TranslationKey.FAILED_TO_OPEN_WINDOW]:
+            '无法打开新窗口以显示 Markdown',
+        },
+        ...zh,
+      },
+    },
+  })
+  .catch(console.error)
+
+const main = async () => {
+  if (!docx.rootBlock) {
+    Toast.warning({ content: i18next.t(TranslationKey.NOT_SUPPORT) })
+    return
+  }
+
+  if (!docx.isReady()) {
+    Toast.warning({
+      content: i18next.t(TranslationKey.CONTENT_LOADING),
+    })
+    return
+  }
+
+  const { root, images } = docx.intoMarkdownAST()
+
+  const tokens = images
+    .map(image => {
+      if (!image.data?.token) return null
+
+      const { token } = image.data
+      const publicUrl = generatePublicUrl(token)
+      const code = new URL(publicUrl).searchParams.get('code')
+      if (!code) return null
+
+      image.url = publicUrl
+      return [token, code]
+    })
+    .filter(isDefined)
+
+  const markdown = Docx.stringify(root)
+
+  if (!window.document.hasFocus()) {
+    const confirmed = await confirm()
+    if (!confirmed) {
+      return
+    }
+  }
+
+  const previewWindow = window.open('', '_blank', 'width=800,height=600')
+
+  if (!previewWindow) {
+    console.error('Failed to open new window.')
+    return
+  }
+
+  previewWindow.document.title = 'Markdown Preview'
+
+  // Wait until the new window’s document is ready
+  previewWindow.onload = () => {
+    const doc = previewWindow.document
+
+    const style = doc.createElement('style')
+    style.textContent = `
+    body {
+      font-family: monospace, system-ui, sans-serif;
+      padding: 20px;
+      background: #f9f9f9;
+      color: #222;
+    }
+    pre {
+      white-space: pre-wrap;
+      word-break: break-word;
+      background: #fff;
+      padding: 1em;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+    }
+    `
+    doc.head.appendChild(style)
+
+    const heading = doc.createElement('h2')
+    heading.textContent = 'Markdown Preview'
+    doc.body.appendChild(heading)
+
+    const pre = doc.createElement('pre')
+    pre.textContent = markdown // Safe, no need to escape
+    doc.body.appendChild(pre)
+  }
+
+  if (tokens.length > 0) {
+    const isSuccess = await makePublicUrlEffective(
+      Object.fromEntries(tokens) as Record<string, string>,
+    )
+    if (!isSuccess) {
+      Toast.error({
+        content: i18next.t(TranslationKey.FAILED_TO_LOAD_IMAGES),
+      })
+    }
+  }
+}
+
+main().catch((error: unknown) => {
+  Toast.error({
+    content: i18next.t(TranslationKey.UNKNOWN_ERROR),
+    actionText: i18next.t(CommonTranslationKey.CONFIRM_REPORT_BUG, {
+      ns: Namespace.COMMON,
+    }),
+    onActionClick: () => {
+      reportBug(error)
+    },
+  })
+})


### PR DESCRIPTION
**Description**
As requested from Issue #1 I have added a 'View MarkDown option on the menu' which on click will open a new pop up window and displays the markdown content.

**Issue**
Fixes: #1 

**Example/Demo**
[View_as_markdown_demo.webm](https://github.com/user-attachments/assets/5f8e6199-3b6c-452b-a82b-bf86011f54fa)

**Checks**

- [ ] The new code matches the existing patterns and styles.
- [ ] The linter passes with `pnpm run lint`.
- [ ] The formatter passes with `pnpm run format-check`
- [ ] The tests pass with `pnpm run test`.
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `pnpm exec changeset add`.)
