### PR TITLE
feat: add support for Feishu text drawing (Mermaid diagrams) in ISV b…

### DIFF
--- a/.changeset/add-isv-mermaid-support.md
+++ b/.changeset/add-isv-mermaid-support.md
@@ -3,10 +3,4 @@
 '@dolphin/chrome-extension': patch
 ---
 
-Add support for Feishu text drawing (Mermaid diagrams) in ISV blocks
-
-- Add ISVBlock interface to support document widgets
-- Remove ISV from NotSupportedBlock and add proper handling
-- Detect Mermaid diagrams by content keywords instead of block_type_id
-- Support 12 types of Mermaid diagrams: mindmap, flowchart, graph, sequenceDiagram, classDiagram, stateDiagram, erDiagram, journey, gantt, pie, gitgraph, timeline
-- Convert ISV text drawing widgets to Markdown code blocks with preserved metadata
+Add support for Text drawing (Mermaid diagrams)

--- a/.changeset/add-isv-mermaid-support.md
+++ b/.changeset/add-isv-mermaid-support.md
@@ -1,0 +1,12 @@
+---
+'@dolphin/lark': minor
+'@dolphin/chrome-extension': patch
+---
+
+Add support for Feishu text drawing (Mermaid diagrams) in ISV blocks
+
+- Add ISVBlock interface to support document widgets
+- Remove ISV from NotSupportedBlock and add proper handling
+- Detect Mermaid diagrams by content keywords instead of block_type_id
+- Support 12 types of Mermaid diagrams: mindmap, flowchart, graph, sequenceDiagram, classDiagram, stateDiagram, erDiagram, journey, gantt, pie, gitgraph, timeline
+- Convert ISV text drawing widgets to Markdown code blocks with preserved metadata


### PR DESCRIPTION
支持 "文本绘图" 组件

- Add ISVBlock interface to support document widgets
- Remove ISV from NotSupportedBlock and add proper handling
- Detect Mermaid diagrams by content keywords instead of block_type_id
- Support 12 types of Mermaid diagrams: mindmap, flowchart, graph, etc.
- Convert ISV text drawing widgets to Markdown code blocks
- Preserve theme and view metadata from original blocks

🤖 Generated with [Claude Code](https://claude.ai/code)

**Description**
A clear and concise description of what this pull request solves.

**Issue**
Fixes: (link to issue)

**Example**
A GIF or video showing the old and new behaviors after this pull request is merged. (If you don't include this, your pull request will not be reviewed as quickly, because it's much too hard to figure out exactly what is going wrong, and it makes maintenance much harder.)

<img width="1809" height="775" alt="image" src="https://github.com/user-attachments/assets/4ed53f79-0168-4c4a-826d-7c8040cf3749" />

**Context**
If your change is non-trivial, please include a description of how the new logic works, and why you decided to solve it the way you did. (This is incredibly helpful so that reviewers don't have to guess your intentions based on the code, and without it your pull request will likely not be reviewed as quickly.)

**Checks**

- [x] The new code matches the existing patterns and styles.
- [x] The linter passes with `pnpm run lint`.
- [x] The formatter passes with `pnpm run format-check`
- [x] The tests pass with `pnpm run test`.
- [x] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `pnpm exec changeset add`.)
