### PR TITLE
fix(lark): Fix nested lists being lost in table cells

### DIFF
--- a/packages/lark/tests/docx/table-lists.test.ts
+++ b/packages/lark/tests/docx/table-lists.test.ts
@@ -1,0 +1,573 @@
+import { describe, expect, it } from 'vitest'
+import { BlockType, Transformer } from '../../src/docx'
+
+const transformer = new Transformer()
+
+describe('table with lists', () => {
+  describe('table cell containing list with formatted content', () => {
+    it('should convert list to HTML tags and preserve formatting', () => {
+      const result = transformer.transform({
+        id: 1,
+        type: BlockType.PAGE,
+        snapshot: {
+          type: BlockType.PAGE,
+        },
+        children: [
+          {
+            id: 2,
+            type: BlockType.TABLE,
+            snapshot: {
+              type: BlockType.TABLE,
+              rows_id: ['row1'],
+              columns_id: ['col1', 'col2'],
+            },
+            children: [
+              {
+                id: 3,
+                type: BlockType.CELL,
+                snapshot: {
+                  type: BlockType.CELL,
+                },
+                children: [
+                  {
+                    id: 4,
+                    type: BlockType.TEXT,
+                    snapshot: {
+                      type: BlockType.TEXT,
+                    },
+                    zoneState: {
+                      allText: '',
+                      content: {
+                        ops: [
+                          {
+                            insert: 'header',
+                            attributes: {},
+                          },
+                        ],
+                      },
+                    },
+                    children: [],
+                  },
+                ],
+              },
+              {
+                id: 5,
+                type: BlockType.CELL,
+                snapshot: {
+                  type: BlockType.CELL,
+                },
+                children: [
+                  {
+                    id: 6,
+                    type: BlockType.BULLET,
+                    snapshot: {
+                      type: BlockType.BULLET,
+                    },
+                    zoneState: {
+                      allText: '',
+                      content: {
+                        ops: [
+                          {
+                            insert: 'plain text',
+                            attributes: {},
+                          },
+                        ],
+                      },
+                    },
+                    children: [],
+                  },
+                  {
+                    id: 7,
+                    type: BlockType.BULLET,
+                    snapshot: {
+                      type: BlockType.BULLET,
+                    },
+                    zoneState: {
+                      allText: '',
+                      content: {
+                        ops: [
+                          {
+                            insert: 'bold text',
+                            attributes: {
+                              bold: 'true',
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    children: [],
+                  },
+                  {
+                    id: 8,
+                    type: BlockType.BULLET,
+                    snapshot: {
+                      type: BlockType.BULLET,
+                    },
+                    zoneState: {
+                      allText: '',
+                      content: {
+                        ops: [
+                          {
+                            insert: 'italic text',
+                            attributes: {
+                              italic: 'true',
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+
+      expect(result.root).toStrictEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'table',
+            children: [
+              {
+                type: 'tableRow',
+                children: [
+                  {
+                    type: 'tableCell',
+                    children: [
+                      {
+                        type: 'text',
+                        value: 'header',
+                      },
+                    ],
+                  },
+                  {
+                    type: 'tableCell',
+                    children: [
+                      {
+                        type: 'html',
+                        value:
+                          '<ul><li>plain text</li><li><strong>bold text</strong></li><li><em>italic text</em></li></ul>',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('should handle nested lists in table cells', () => {
+      const result = transformer.transform({
+        id: 1,
+        type: BlockType.PAGE,
+        snapshot: {
+          type: BlockType.PAGE,
+        },
+        children: [
+          {
+            id: 2,
+            type: BlockType.TABLE,
+            snapshot: {
+              type: BlockType.TABLE,
+              rows_id: ['row1'],
+              columns_id: ['col1'],
+            },
+            children: [
+              {
+                id: 3,
+                type: BlockType.CELL,
+                snapshot: {
+                  type: BlockType.CELL,
+                },
+                children: [
+                  {
+                    id: 4,
+                    type: BlockType.BULLET,
+                    snapshot: {
+                      type: BlockType.BULLET,
+                    },
+                    zoneState: {
+                      allText: '',
+                      content: {
+                        ops: [
+                          {
+                            insert: 'parent item',
+                            attributes: {},
+                          },
+                        ],
+                      },
+                    },
+                    children: [
+                      {
+                        id: 5,
+                        type: BlockType.BULLET,
+                        snapshot: {
+                          type: BlockType.BULLET,
+                        },
+                        zoneState: {
+                          allText: '',
+                          content: {
+                            ops: [
+                              {
+                                insert: 'child item',
+                                attributes: {},
+                              },
+                            ],
+                          },
+                        },
+                        children: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+
+      expect(result.root).toStrictEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'table',
+            children: [
+              {
+                type: 'tableRow',
+                children: [
+                  {
+                    type: 'tableCell',
+                    children: [
+                      {
+                        type: 'html',
+                        value:
+                          '<ul><li>parent item<ul><li>child item</li></ul></li></ul>',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('should handle deeply nested lists in table cells', () => {
+      const result = transformer.transform({
+        id: 1,
+        type: BlockType.PAGE,
+        snapshot: {
+          type: BlockType.PAGE,
+        },
+        children: [
+          {
+            id: 2,
+            type: BlockType.TABLE,
+            snapshot: {
+              type: BlockType.TABLE,
+              rows_id: ['row1'],
+              columns_id: ['col1'],
+            },
+            children: [
+              {
+                id: 3,
+                type: BlockType.CELL,
+                snapshot: {
+                  type: BlockType.CELL,
+                },
+                children: [
+                  {
+                    id: 4,
+                    type: BlockType.BULLET,
+                    snapshot: {
+                      type: BlockType.BULLET,
+                    },
+                    zoneState: {
+                      allText: '',
+                      content: {
+                        ops: [
+                          {
+                            insert: '条件4：单选，枚举值如下',
+                            attributes: {
+                              bold: 'true',
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    children: [
+                      {
+                        id: 5,
+                        type: BlockType.BULLET,
+                        snapshot: {
+                          type: BlockType.BULLET,
+                        },
+                        zoneState: {
+                          allText: '',
+                          content: {
+                            ops: [
+                              {
+                                insert: '货单节点',
+                                attributes: {},
+                              },
+                            ],
+                          },
+                        },
+                        children: [
+                          {
+                            id: 6,
+                            type: BlockType.BULLET,
+                            snapshot: {
+                              type: BlockType.BULLET,
+                            },
+                            zoneState: {
+                              allText: '',
+                              content: {
+                                ops: [
+                                  {
+                                    insert: '接单完成',
+                                    attributes: {},
+                                  },
+                                ],
+                              },
+                            },
+                            children: [],
+                          },
+                          {
+                            id: 7,
+                            type: BlockType.BULLET,
+                            snapshot: {
+                              type: BlockType.BULLET,
+                            },
+                            zoneState: {
+                              allText: '',
+                              content: {
+                                ops: [
+                                  {
+                                    insert: '备货完成',
+                                    attributes: {},
+                                  },
+                                ],
+                              },
+                            },
+                            children: [],
+                          },
+                          {
+                            id: 8,
+                            type: BlockType.BULLET,
+                            snapshot: {
+                              type: BlockType.BULLET,
+                            },
+                            zoneState: {
+                              allText: '',
+                              content: {
+                                ops: [
+                                  {
+                                    insert: '进仓完成',
+                                    attributes: {},
+                                  },
+                                ],
+                              },
+                            },
+                            children: [
+                              {
+                                id: 9,
+                                type: BlockType.BULLET,
+                                snapshot: {
+                                  type: BlockType.BULLET,
+                                },
+                                zoneState: {
+                                  allText: '',
+                                  content: {
+                                    ops: [
+                                      {
+                                        insert: '之前x天',
+                                        attributes: {},
+                                      },
+                                    ],
+                                  },
+                                },
+                                children: [],
+                              },
+                              {
+                                id: 10,
+                                type: BlockType.BULLET,
+                                snapshot: {
+                                  type: BlockType.BULLET,
+                                },
+                                zoneState: {
+                                  allText: '',
+                                  content: {
+                                    ops: [
+                                      {
+                                        insert: '当天',
+                                        attributes: {},
+                                      },
+                                    ],
+                                  },
+                                },
+                                children: [],
+                              },
+                              {
+                                id: 11,
+                                type: BlockType.BULLET,
+                                snapshot: {
+                                  type: BlockType.BULLET,
+                                },
+                                zoneState: {
+                                  allText: '',
+                                  content: {
+                                    ops: [
+                                      {
+                                        insert: '之后x天',
+                                        attributes: {},
+                                      },
+                                    ],
+                                  },
+                                },
+                                children: [],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+
+      expect(result.root).toStrictEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'table',
+            children: [
+              {
+                type: 'tableRow',
+                children: [
+                  {
+                    type: 'tableCell',
+                    children: [
+                      {
+                        type: 'html',
+                        value:
+                          '<ul><li><strong>条件4：单选，枚举值如下</strong><ul><li>货单节点<ul><li>接单完成</li><li>备货完成</li><li>进仓完成<ul><li>之前x天</li><li>当天</li><li>之后x天</li></ul></li></ul></li></ul></li></ul>',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    })
+
+    it('should handle ordered lists in table cells', () => {
+      const result = transformer.transform({
+        id: 1,
+        type: BlockType.PAGE,
+        snapshot: {
+          type: BlockType.PAGE,
+        },
+        children: [
+          {
+            id: 2,
+            type: BlockType.TABLE,
+            snapshot: {
+              type: BlockType.TABLE,
+              rows_id: ['row1'],
+              columns_id: ['col1'],
+            },
+            children: [
+              {
+                id: 3,
+                type: BlockType.CELL,
+                snapshot: {
+                  type: BlockType.CELL,
+                },
+                children: [
+                  {
+                    id: 4,
+                    type: BlockType.ORDERED,
+                    snapshot: {
+                      type: BlockType.ORDERED,
+                      seq: '1',
+                    },
+                    zoneState: {
+                      allText: '',
+                      content: {
+                        ops: [
+                          {
+                            insert: 'first',
+                            attributes: {},
+                          },
+                        ],
+                      },
+                    },
+                    children: [],
+                  },
+                  {
+                    id: 5,
+                    type: BlockType.ORDERED,
+                    snapshot: {
+                      type: BlockType.ORDERED,
+                      seq: '2',
+                    },
+                    zoneState: {
+                      allText: '',
+                      content: {
+                        ops: [
+                          {
+                            insert: 'second',
+                            attributes: {},
+                          },
+                        ],
+                      },
+                    },
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+
+      expect(result.root).toStrictEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'table',
+            children: [
+              {
+                type: 'tableRow',
+                children: [
+                  {
+                    type: 'tableCell',
+                    children: [
+                      {
+                        type: 'html',
+                        value: '<ol><li>first</li><li>second</li></ol>',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      })
+    })
+  })
+})


### PR DESCRIPTION
  - Add nodeToHtml helper function to convert lists to HTML tags
  - Use mergeListItems to merge list items before processing table cell content
  - Support arbitrary depth nested ordered/unordered lists
  - Preserve text formatting (bold, italic, links, etc.)
  - Filter out empty list items
  - Add 4 test cases covering various nesting scenarios

**Description**
When converting Feishu documents to Markdown, lists (including nested lists) in table cells are lost. This is
   because standard Markdown tables do not support multi-line content and list structures.

**Issue**
Fixes: [#75](https://github.com/whale4113/cloud-document-converter/issues/75)

**Example**
- Unordered lists in tables cannot be rendered correctly
- Nested list structures are flattened or lost
- Text formatting (bold, italic) in lists is lost

**Context**
Preserve list structures in table cells by converting lists to HTML tags:

  1. **Add `nodeToHtml` helper function**
     - Recursively process mdast node tree
     - Convert list nodes to `<ul>` and `<ol>` HTML tags
     - Preserve all text formatting (`<strong>`, `<em>`, `<a>`, etc.)

  2. **Improve table cell processing logic**
     - Use `mergeListItems` to merge list items before processing
     - Convert list nodes to HTML nodes
     - Filter out empty list items

  3. **Supported features**
     - ✅ Unordered lists (`<ul>`)
     - ✅ Ordered lists (`<ol>`)
     - ✅ Arbitrary depth nested lists
     - ✅ Preserve bold, italic, strikethrough, links, etc.
     - ✅ Automatically filter empty content

**Test Results**
  \`\`\`
  ✓ tests/docx/hr.test.ts  (1 test)
  ✓ tests/docx/table-lists.test.ts  (4 tests)
  ✓ tests/docx.test.ts  (23 tests)

  Test Files  3 passed (3)
        Tests  28 passed (28)
  \`\`\`

  ## 📝 Modified Files

  - \`packages/lark/src/docx.ts\` (+95, -14)
  - \`packages/lark/tests/docx/table-lists.test.ts\` (new file, 573 lines)

  ## 🔍 Checklist

  - [x] All tests pass
  - [x] TypeScript type checking passes
  - [x] Build succeeds
  - [x] Prettier formatting completed
  - [x] ESLint checks pass
  - [x] Maintains backward compatibility
  - [x] Added test cases

**Checks**

- [ ] The new code matches the existing patterns and styles.
- [ ] The linter passes with `pnpm run lint`.
- [ ] The formatter passes with `pnpm run format-check`
- [ ] The tests pass with `pnpm run test`.
- [ ] You've [added a changeset](https://github.com/atlassian/changesets/blob/master/docs/adding-a-changeset.md) if changing functionality. (Add one with `pnpm exec changeset add`.)
