### PR TITLE
fix(lark): whiteboard exported as blank image with abnormal dimensions

### DIFF
--- a/.changeset/whiteboard-blank-export.md
+++ b/.changeset/whiteboard-blank-export.md
@@ -1,0 +1,7 @@
+---
+'@dolphin/lark': patch
+---
+
+fix: whiteboard exported as a blank image with abnormal dimensions when captured before its content finished loading
+
+Wait for the whiteboard's scene to have non-empty bounds before capturing, and fall back to the isolateEnv path when the app path cannot produce a valid image.

--- a/packages/lark/src/docx.ts
+++ b/packages/lark/src/docx.ts
@@ -958,43 +958,87 @@ const fetchImageSources = (imageBlock: ImageBlock) =>
       .catch(reject)
   })
 
-const whiteboardToBlob = async (
-  whiteboard: Whiteboard,
-): Promise<Blob | null> => {
-  if (!whiteboard.whiteboardBlock) return null
+/**
+ * @description Whether the whiteboard's scene has finished loading and can be
+ * captured. Merely having `whiteboardBlock` defined is not enough: when the
+ * block is captured before its nodes are laid out, `getNodesBounds()` returns a
+ * degenerate box, producing a blank image with abnormal dimensions.
+ */
+const isWhiteboardContentReady = (whiteboard: Whiteboard): boolean => {
+  const block = whiteboard.whiteboardBlock
+  if (!block) return false
 
-  const padding = 24
-  const ratio = window.devicePixelRatio
-  const backgroundColor = '#ffffff'
+  const ratioApp = block.abilityKit.getRatioApp()
+  if (ratioApp.app) {
+    const { minX, maxX, minY, maxY } =
+      ratioApp.app.application.nodeManager.getNodesBounds()
 
-  let rationApp = whiteboard.whiteboardBlock.abilityKit.getRatioApp()
-
-  if (rationApp.app) {
-    const bounds = rationApp.app.application.nodeManager.getNodesBounds()
-    bounds.maxX += padding
-    bounds.minX -= padding
-    bounds.maxY += padding
-    bounds.minY -= padding
-
-    const canvas = rationApp.app.renderManager.getImageOffscreenCanvas(
-      bounds,
-      ratio,
-      backgroundColor,
-    )
-
-    if (!canvas) return null
-
-    return new Promise(resolve => {
-      checkCanvasDimensions(canvas)
-
-      canvas.toBlob(resolve)
-    })
+    // The app path can render once its scene has non-empty bounds.
+    if (maxX - minX > 0 && maxY - minY > 0) return true
   }
 
-  rationApp = whiteboard.whiteboardBlock.isolateEnv.getRatioApp()
+  // Otherwise fall back to the isolateEnv path's own readiness signal.
+  return block.isolateEnv.hasRatioApp()
+}
+
+interface WhiteboardCaptureOptions {
+  padding: number
+  ratio: number
+  backgroundColor: string
+}
+
+/**
+ * @description Capture via the new `abilityKit` app path. Returns `null` when it
+ * cannot produce a valid image (no app, empty scene bounds, or no canvas) so the
+ * caller can fall back to the isolateEnv path.
+ */
+const whiteboardAppToBlob = async (
+  block: WhiteboardBlock,
+  { padding, ratio, backgroundColor }: WhiteboardCaptureOptions,
+): Promise<Blob | null> => {
+  const ratioApp = block.abilityKit.getRatioApp()
+  if (!ratioApp.app) return null
+
+  const bounds = ratioApp.app.application.nodeManager.getNodesBounds()
+
+  // A degenerate box means the scene is not laid out yet; bail so we don't emit
+  // a blank image with padding-only dimensions.
+  if (bounds.maxX - bounds.minX <= 0 || bounds.maxY - bounds.minY <= 0) {
+    return null
+  }
+
+  bounds.maxX += padding
+  bounds.minX -= padding
+  bounds.maxY += padding
+  bounds.minY -= padding
+
+  const canvas = ratioApp.app.renderManager.getImageOffscreenCanvas(
+    bounds,
+    ratio,
+    backgroundColor,
+  )
+
+  if (!canvas) return null
+
+  return await new Promise<Blob | null>(resolve => {
+    checkCanvasDimensions(canvas)
+
+    canvas.toBlob(resolve)
+  })
+}
+
+/**
+ * @description Capture via the legacy `isolateEnv` path. Used as a fallback when
+ * the app path is unavailable or its scene bounds are still empty.
+ */
+const whiteboardIsolateEnvToBlob = async (
+  block: WhiteboardBlock,
+  { padding, ratio }: WhiteboardCaptureOptions,
+): Promise<Blob | null> => {
+  const ratioApp = block.isolateEnv.getRatioApp()
 
   const imageDataWrapper =
-    await rationApp.ratioAppProxy.getOriginImageDataByNodeId(
+    await ratioApp.ratioAppProxy.getOriginImageDataByNodeId(
       padding,
       [''],
       false,
@@ -1006,6 +1050,26 @@ const whiteboardToBlob = async (
   return await imageDataToBlob(imageDataWrapper.data, {
     onDispose: imageDataWrapper.release,
   })
+}
+
+const whiteboardToBlob = async (
+  whiteboard: Whiteboard,
+): Promise<Blob | null> => {
+  const block = whiteboard.whiteboardBlock
+  if (!block) return null
+
+  const options: WhiteboardCaptureOptions = {
+    padding: 24,
+    ratio: window.devicePixelRatio,
+    backgroundColor: '#ffffff',
+  }
+
+  // Prefer the app path; fall back to isolateEnv when it can't produce a valid
+  // image (e.g. app exists but its scene bounds are still empty).
+  return (
+    (await whiteboardAppToBlob(block, options)) ??
+    (await whiteboardIsolateEnvToBlob(block, options))
+  )
 }
 
 const diagramToSVGElement = (diagram: DiagramBlock): SVGElement | null => {
@@ -1386,10 +1450,13 @@ export class Transformer {
                     () =>
                       locateBlockWithRecordId(whiteboard.record?.id ?? '').then(
                         isSuccess =>
-                          isSuccess && whiteboard.whiteboardBlock !== undefined,
+                          isSuccess && isWhiteboardContentReady(whiteboard),
                       ),
                     {
-                      timeout: 3 * Second,
+                      // Heavy whiteboards may take a while to lay out after the
+                      // block is located; keep polling so we don't capture an
+                      // empty scene (a blank image with padding-only dimensions).
+                      timeout: 10 * Second,
                     },
                   )
                 } catch (error) {

--- a/packages/lark/src/docx.ts
+++ b/packages/lark/src/docx.ts
@@ -334,9 +334,9 @@ interface ImageDataWrapper {
 }
 
 interface RatioApp {
-  ratioAppProxy: {
+  ratioAppProxy?: {
     getOriginImageDataByNodeId: (
-      i: 24,
+      i: number,
       o: [''],
       r: false,
       n: number,
@@ -978,7 +978,10 @@ const isWhiteboardContentReady = (whiteboard: Whiteboard): boolean => {
   }
 
   // Otherwise fall back to the isolateEnv path's own readiness signal.
-  return block.isolateEnv.hasRatioApp()
+  return (
+    block.isolateEnv.hasRatioApp() &&
+    block.isolateEnv.getRatioApp().ratioAppProxy !== undefined
+  )
 }
 
 interface WhiteboardCaptureOptions {
@@ -1038,7 +1041,7 @@ const whiteboardIsolateEnvToBlob = async (
   const ratioApp = block.isolateEnv.getRatioApp()
 
   const imageDataWrapper =
-    await ratioApp.ratioAppProxy.getOriginImageDataByNodeId(
+    await ratioApp.ratioAppProxy?.getOriginImageDataByNodeId(
       padding,
       [''],
       false,


### PR DESCRIPTION

Description（描述）

修复**画板（Whiteboard）下载为白底空图、且尺寸异常（如 72×72）**的问题。

画板在场景内容尚未加载完成时就被截图：截图前的就绪判断只检查了 whiteboardBlock 对象是否存在，导致在画板节点还没排版好时就调用了 getNodesBounds()，拿到一个空包围盒。空盒加上 padding 再乘以 devicePixelRatio，最终输出了一张只有 padding 尺寸的纯白图（例如 0 → +24×2 → 48 → ×1.5 = 72px）。

主要改动：

新增 isWhiteboardContentReady()，将"截图就绪"的判据从"块对象存在"改为"场景包围盒非空（宽高 > 0）"
当 app 路径拿到退化的空包围盒时主动放弃，自动回退到 isolateEnv 路径，使 app 包围盒持续为空的画板仍能正常导出
将就绪等待的超时从 3 秒放宽到 10 秒，给内容较多的画板足够的渲染时间
Issue

Fixes: https://github.com/whale4113/cloud-document-converter/issues/133

Context（实现说明）

画板的导出尺寸完全由 getNodesBounds() 返回的包围盒决定，因此"尺寸异常"直接说明截图发生在节点测量就绪之前。